### PR TITLE
Add django 1.6 compatibility

### DIFF
--- a/idptest/saml2idp/urls.py
+++ b/idptest/saml2idp/urls.py
@@ -1,6 +1,11 @@
-from django.conf.urls.defaults import *
 from views import descriptor, login_begin, login_init, login_process, logout
 from metadata import get_deeplink_resources
+
+try:
+    # Django <1.6
+    from django.conf.urls.defaults import *
+except ImportError:
+    from django.conf.urls import *
 
 def deeplink_url_patterns(
     prefix='',

--- a/idptest/saml2idp/views.py
+++ b/idptest/saml2idp/views.py
@@ -83,6 +83,7 @@ def login_init(request, resource, **kwargs):
     return _generate_response(request, proc)
 
 @login_required
+@csrf_response_exempt
 def login_process(request):
     """
     Processor-based login continuation.

--- a/idptest/saml2idp/views.py
+++ b/idptest/saml2idp/views.py
@@ -19,8 +19,10 @@ import xml_signing
 
 try:
     # Django <1.6
-    from django.views.decorators.csrf import (csrf_view_exempt as csrf_exempt,
-                                             csrf_response_exempt)
+    from django.views.decorators.csrf import (
+        csrf_view_exempt as csrf_exempt,
+        csrf_response_exempt
+    )
 except ImportError:
     from django.views.decorators.csrf import csrf_exempt
 

--- a/idptest/saml2idp/views.py
+++ b/idptest/saml2idp/views.py
@@ -10,13 +10,23 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, redirect
 from django.template import RequestContext
-from django.views.decorators.csrf import csrf_view_exempt, csrf_response_exempt
 # saml2idp app imports:
 import saml2idp_metadata
 import exceptions
 import metadata
 import registry
 import xml_signing
+
+try:
+    # Django <1.6
+    from django.views.decorators.csrf import (csrf_view_exempt as csrf_exempt,
+                                             csrf_response_exempt)
+except ImportError:
+    from django.views.decorators.csrf import csrf_exempt
+
+    def csrf_response_exempt(func):
+        return func
+
 
 def _generate_response(request, processor):
     """
@@ -35,7 +45,7 @@ def _generate_response(request, processor):
 def xml_response(request, template, tv):
     return render_to_response(template, tv, mimetype="application/xml")
 
-@csrf_view_exempt
+@csrf_exempt
 def login_begin(request, *args, **kwargs):
     """
     Receives a SAML 2.0 AuthnRequest from a Service Provider and
@@ -73,7 +83,6 @@ def login_init(request, resource, **kwargs):
     return _generate_response(request, proc)
 
 @login_required
-@csrf_response_exempt
 def login_process(request):
     """
     Processor-based login continuation.
@@ -84,7 +93,7 @@ def login_process(request):
     proc = registry.find_processor(request)
     return _generate_response(request, proc)
 
-@csrf_view_exempt
+@csrf_exempt
 def logout(request):
     """
     Allows a non-SAML 2.0 URL to log out the user and
@@ -97,7 +106,7 @@ def logout(request):
                                 context_instance=RequestContext(request))
 
 @login_required
-@csrf_view_exempt
+@csrf_exempt
 def slo_logout(request):
     """
     Receives a SAML 2.0 LogoutRequest from a Service Provider,

--- a/idptest/urls.py
+++ b/idptest/urls.py
@@ -1,8 +1,12 @@
-from django.conf.urls.defaults import *
-
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
+
+try:
+    # Django <1.6
+    from django.conf.urls.defaults import *
+except ImportError:
+    from django.conf.urls import *
 
 urlpatterns = patterns('',
     # Example:


### PR DESCRIPTION
A few of the view decorators used by django-saml2-idp were either moved to different modules, or removed completely, in Django 1.6.

I've attempted to maintain backwards compatibility with <1.6 in the simplest way possible.
